### PR TITLE
fixed timeunit conversion and added return the future get method

### DIFF
--- a/src/main/java/io/forty11/web/Web.java
+++ b/src/main/java/io/forty11/web/Web.java
@@ -87,6 +87,7 @@ public class Web
    static Executor      pool                     = null;
    static Timer         timer                    = null;
 
+   
    public static FutureResponse get(String url)
    {
       return rest(new Request("GET", url));
@@ -692,7 +693,7 @@ public class Web
             log.warn(msg, ex);
          }
          
-         timeout = unit.convert(timeout, TimeUnit.MILLISECONDS);
+         timeout = TimeUnit.MILLISECONDS.convert(timeout, unit);
          while (response == null)
          {
             synchronized (this)
@@ -702,6 +703,9 @@ public class Web
                   try
                   {
                      wait(timeout);
+                     // return because we hit the timeout and can't wait any longer 
+                     // (or we could throw an exception) response will most likely be null
+                     return response;
                   }
                   catch (Exception ex)
                   {


### PR DESCRIPTION
I think this fixes it.  The unit conversion code didn't work before and always returned 0.  I think we just need to return (or throw an exception) after the wait() call.

This is the main I used to test this...

```java
 public static void main(String[] args)
    {
       try
       {
          long s = System.currentTimeMillis();
          FutureResponse future = Web.get("http://httpbin.org/delay/00009", 1);

          Response res = future.get(5L, TimeUnit.SECONDS);
          long e = System.currentTimeMillis();
          
          System.out.println(e-s);
          if(res != null) {
             System.out.println(res.getContent());
             System.out.println(res);
          }else {
             System.out.println("timed out");
          }
       }
       catch (Exception e)
       {
          e.printStackTrace();
       }

    }
```